### PR TITLE
Add responsive portfolio layout and styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Portfolio Website
+
+Simple responsive portfolio site built with HTML and CSS.
+
+## Development
+
+Open `index.html` in your browser to view the site.
+
+## Tests
+
+No automated tests are configured.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Portfolio</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="site-header">
+    <nav class="nav">
+      <a href="#about">About</a>
+      <a href="#projects">Projects</a>
+      <a href="#contact">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <section class="hero">
+      <h1>Welcome</h1>
+      <p>My name is Your Name, I build awesome things.</p>
+      <a class="cta" href="#projects">See My Work</a>
+    </section>
+    <section id="about" class="section">
+      <h2>About</h2>
+      <p>Brief description about me and my passion for creating engaging user experiences.</p>
+    </section>
+    <section id="projects" class="section">
+      <h2>Projects</h2>
+      <div class="project-grid">
+        <div class="project-card">
+          <h3>Project 1</h3>
+          <p>Short description.</p>
+        </div>
+        <div class="project-card">
+          <h3>Project 2</h3>
+          <p>Short description.</p>
+        </div>
+      </div>
+    </section>
+    <section id="contact" class="section">
+      <h2>Contact</h2>
+      <p>Email: <a href="mailto:example@example.com">example@example.com</a></p>
+    </section>
+  </main>
+  <footer class="site-footer">
+    <p>&copy; 2024 Your Name</p>
+  </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,98 @@
+:root {
+  --primary-color: #1e90ff;
+  --dark-color: #333;
+  --light-color: #fff;
+  --max-width: 960px;
+  --font-body: 'Arial', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-body);
+  line-height: 1.6;
+  color: var(--dark-color);
+  background: #f5f5f5;
+}
+
+.nav {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  padding: 1rem 0;
+  background: var(--light-color);
+  position: sticky;
+  top: 0;
+}
+
+.nav a {
+  color: var(--dark-color);
+  text-decoration: none;
+  font-weight: bold;
+  transition: color 0.3s;
+}
+
+.nav a:hover {
+  color: var(--primary-color);
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 4rem 1rem;
+  background: var(--primary-color);
+  color: var(--light-color);
+  text-align: center;
+}
+
+.hero .cta {
+  margin-top: 1.5rem;
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: var(--light-color);
+  color: var(--primary-color);
+  border-radius: 4px;
+  text-decoration: none;
+  transition: background 0.3s, color 0.3s;
+}
+
+.hero .cta:hover {
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.section {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 4rem 1rem;
+}
+
+.project-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.project-card {
+  background: var(--light-color);
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s;
+}
+
+.project-card:hover {
+  transform: translateY(-4px);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem;
+  background: var(--dark-color);
+  color: var(--light-color);
+}


### PR DESCRIPTION
## Summary
- build responsive HTML layout with navigation, hero, project and contact sections
- style site with CSS variables, grid layout, and interactive project cards
- add README with basic usage info

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689df9df38d0832488d693a1022ab370